### PR TITLE
Handle conversion of Conditional Cloudformation Resources

### DIFF
--- a/src/cf2tf/conversion/expressions.py
+++ b/src/cf2tf/conversion/expressions.py
@@ -796,6 +796,11 @@ def ref(template: "TemplateConverter", var_name: str):
         tf_name = cf2tf.convert.pascal_to_snake(var_name)
         tf_type = cf2tf.convert.create_resource_type(docs_path)
         first_attr = next(iter(valid_attributes))
+        conditional = cf_resource.get("Condition")
+
+        if conditional is not None:
+            tf_name = f"{tf_name}[0]"
+
         return LiteralType(f"{tf_type}.{tf_name}.{first_attr}")
 
     raise ValueError(f"Fn::Ref - {var_name} is not a valid Resource or Parameter.")

--- a/src/cf2tf/terraform/hcl2/_block.py
+++ b/src/cf2tf/terraform/hcl2/_block.py
@@ -50,10 +50,16 @@ class Block:
         return self.render()
 
     def ref(self, attribute_name: Optional[str] = None):
-        if not attribute_name:
-            return LiteralType(f"{self.base_ref()}.{self.valid_attributes[0]}")
 
-        return LiteralType(f"{self.base_ref()}.{attribute_name}")
+        count = "[0]" if "count" in self.arguments else ""
+
+        resource_name = f"{self.base_ref()}{count}"
+
+        attribute = (
+            self.valid_attributes[0] if attribute_name is None else attribute_name
+        )
+
+        return LiteralType(f"{resource_name}.{attribute}")
 
     def render(self, indent=0):
 

--- a/tests/test_conversion/test_expressions.py
+++ b/tests/test_conversion/test_expressions.py
@@ -513,6 +513,22 @@ def test_ref(input, expected_result, expectation):
         assert result == expected_result
 
 
+def test_ref_conditional():
+
+    cf_manifest = {
+        "Parameters": [("foo", {"a": "a"})],
+        "Resources": [("bar", {"Type": "AWS::S3::Bucket", "Condition": "Foo"})],
+    }
+
+    sm = code.search_manager()
+
+    tc = TemplateConverter("test", {}, sm)
+    tc.manifest = cf_manifest
+
+    result = expressions.ref(tc, "bar")
+    assert result == "aws_s3_bucket.bar[0].id"
+
+
 select_tests = [
     # (input, expected_result, expectation, block)
     ({}, None, pytest.raises(TypeError)),


### PR DESCRIPTION
Before this PR Cloudformation `Conditions` were being resolved to their final value and were being used in other expressions when converting to Terraform. But the handling of conditional resources was not yet implemented. This PR now handles the conversion of a conditional resource from Cloudformation to Terraform. The change was to add the "count" argument to the Terraform resource with the correct ternary operator and then to make sure references to this resource added the index `[0]`.

```HCL
resource "aws_s3_bucket" "logs_bucket" {
  count = locals.DeleteBucket ? 1 : 0
  bucket = "${var.bucket_prefix}-logs-${data.aws_region.current.name}"
}

resource "aws_s3_bucket" "retain_logs_bucket" {
  count = locals.RetainBucket ? 1 : 0
  bucket = "${var.bucket_prefix}-logs-${data.aws_region.current.name}"
}

output "logs_bucket_name" {
  description = "Name of the logs bucket."
  value = local.RetainBucket ? aws_s3_bucket.retain_logs_bucket[0].id : aws_s3_bucket.logs_bucket[0].id
}
```