### PR TITLE
Add override system to manually fix conversion errors

### DIFF
--- a/src/cf2tf/conversion/overrides.py
+++ b/src/cf2tf/conversion/overrides.py
@@ -1,0 +1,52 @@
+from typing import TYPE_CHECKING, Callable, Dict
+
+from cf2tf.terraform.hcl2.custom import LiteralType
+from cf2tf.terraform.hcl2.primitive import NullType, StringType, TerraformType
+
+if TYPE_CHECKING:
+    from cf2tf.convert import TemplateConverter
+
+CFParams = Dict[str, TerraformType]
+
+Override = Callable[["TemplateConverter", CFParams], CFParams]
+
+ParamOverride = Dict[str, Override]
+
+ResourceOverride = Dict[str, ParamOverride]
+
+
+def s3_bucket_acl(_tc: "TemplateConverter", params: CFParams) -> CFParams:
+    access_controls: CFParams = {
+        "Private": StringType("private"),
+        "PublicRead": StringType("public-read"),
+        "PublicReadWrite": StringType("public-read-write"),
+        "AuthenticatedRead": StringType("authenticated-read"),
+        "LogDeliveryWrite": StringType("log-delivery-write"),
+        "BucketOwnerRead": NullType(),
+        "BucketOwnerFullControl": NullType(),
+        "AwsExecRead": StringType("aws-exec-read"),
+    }
+
+    orig_value = params["AccessControl"]
+
+    new_value = access_controls[orig_value]  # type: ignore
+
+    del params["AccessControl"]
+
+    params["acl"] = new_value
+    return params
+
+
+def s3_bucket_policy(_tc: "TemplateConverter", params: CFParams) -> CFParams:
+
+    policy_value = params["PolicyDocument"]
+
+    params["PolicyDocument"] = LiteralType(f"jsonencode({policy_value.render(4)}\n  )")
+
+    return params
+
+
+OVERRIDE_DISPATCH: ResourceOverride = {
+    "aws_s3_bucket": {"AccessControl": s3_bucket_acl},
+    "aws_s3_bucket_policy": {"PolicyDocument": s3_bucket_policy},
+}

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -7,6 +7,7 @@ import pytest
 import cf2tf.convert as convert
 from cf2tf.terraform import code, doc_file
 from cf2tf.terraform.blocks import Data, Locals, Output
+from cf2tf.terraform.hcl2.primitive import StringType
 
 
 def tc():
@@ -133,3 +134,24 @@ def test_get_block_by_type():
     block = template.get_block_by_type(Output)
 
     assert block is None
+
+
+def test_perform_resource_overrides():
+
+    template = tc()
+
+    fake_params = {"foo": StringType("bar")}
+
+    result = convert.perform_resource_overrides("fake_resource", fake_params, template)
+
+    assert result is fake_params
+
+    params = {"AccessControl": StringType("Private")}
+
+    result = convert.perform_resource_overrides("aws_s3_bucket", params, tc)
+
+    assert result is params
+
+    assert "AccessControl" not in result
+    assert "acl" in result
+    assert "private" == result["acl"]


### PR DESCRIPTION
While cf2tf does a decent job at converting the Cloudformation Syntax to HCL2 syntax, it does not usually produce valid terraform templates. This is a know issue that is outlined in our README. Recent improvements to cf2tf like #84, means that cf2tf does almost all the work that it can do on its own and it just needs little more help in order to convert resources perfectly. 

This PR adds an override system so that the conversion of resources can be manually fixed. I have included a couple of examples. The first example changes the value of a cf parameter to one that is compatible with terraform. 

Before:
```hcl
resource "aws_s3_bucket_policy" "cl_bucket_policy_f1_df7_d4_f" {
  bucket = aws_s3_bucket.cl_bucket116_f9_f6_b.id
  policy = {
    Statement = [
      {
        Action = [
          "s3:Put*",
          "s3:Get*"
        ]
        Effect = "Allow"
        Principal = {
          AWS = aws_iam_role.firehose_role_aa67_c190.arn
        }
        Resource = [
          aws_s3_bucket.cl_bucket116_f9_f6_b.arn,
          join("", [aws_s3_bucket.cl_bucket116_f9_f6_b.arn, "/*"])
        ]
      }
    ]
    Version = "2012-10-17"
  }
}
````

The problem here is that `policy` takes a json string. But this is something we can easily fix by wrapping the value in a `jsonencode()`.

now:
```hcl
resource "aws_s3_bucket_policy" "cl_bucket_policy_f1_df7_d4_f" {
  bucket = aws_s3_bucket.cl_bucket116_f9_f6_b.id
  policy = jsonencode({
      Statement = [
        {
          Action = [
            "s3:Put*",
            "s3:Get*"
          ]
          Effect = "Allow"
          Principal = {
            AWS = aws_iam_role.firehose_role_aa67_c190.arn
          }
          Resource = [
            aws_s3_bucket.cl_bucket116_f9_f6_b.arn,
            join("", [aws_s3_bucket.cl_bucket116_f9_f6_b.arn, "/*"])
          ]
        }
      ]
      Version = "2012-10-17"
    }
  )
}
```

We are not just limited to changing a value but we can also rename/remove arguments. 

before:
```hcl
resource "aws_s3_bucket" "s3_bucket" {
  bucket = "public-bucket"
  // CF Property(AccessControl) = "PublicRead"
}
```

The cf parameter `AccessControl` ends up commented out because we are unable to automatically match it to `acl` in tf. Not only that but the values in tf are different than cf.

now:
```hcl
resource "aws_s3_bucket" "s3_bucket" {
  bucket = "public-bucket"
  acl = "public-read"
}
```
We can override the value and add it back with a new key and remove the old one.


These were just two examples to show people how the override system works in the hope that people might add additional ones for the more common resources. The override system is also capable of doing a lot more, like adding/removing other resources etc. 