### PR TITLE
fix substitution issue where literal dollar sign in string is treated like variable in list arguments

### DIFF
--- a/src/cf2tf/conversion/expressions.py
+++ b/src/cf2tf/conversion/expressions.py
@@ -748,7 +748,7 @@ def sub_l(template: "TemplateConverter", values: List):
         )
 
     def replace_var(m):
-        var: str = m.group(2)
+        var: str = m.group(1)
 
         if var in local_vars:
             result = local_vars[var]
@@ -758,7 +758,7 @@ def sub_l(template: "TemplateConverter", values: List):
 
         return wrap_in_curlys(result)
 
-    reVar = r"(?!\$\{\!)\$(\w+|\{([^}]*)\})"
+    reVar = r"(?!\$\{\!)\$\{(\w+[^}]*)\}"
 
     if re.search(reVar, source_string):
         return StringType(

--- a/tests/test_conversion/test_expressions.py
+++ b/tests/test_conversion/test_expressions.py
@@ -687,8 +687,8 @@ sub_l_tests = [
         hcl2.Variable("foo", {"value": "bar"}),
     ),
     (
-        ["bash $foo and Cloudformation ${foo}", {"foo": "bar"}],
-        "bash $foo and Cloudformation bar",
+        ["bash $foo and Cloudformation ${foo}", {"foo": "var.bar"}],
+        "bash $foo and Cloudformation ${var.bar}",
         no_exception(),
         hcl2.Variable("foo", {"value": "bar"}),
     ),

--- a/tests/test_conversion/test_expressions.py
+++ b/tests/test_conversion/test_expressions.py
@@ -687,8 +687,8 @@ sub_l_tests = [
         hcl2.Variable("foo", {"value": "bar"}),
     ),
     (
-        ["some $foo", {"foo": "bar"}],
-        "some $foo",
+        ["bash $foo and Cloudformation ${foo}", {"foo": "bar"}],
+        "bash $foo and Cloudformation bar",
         no_exception(),
         hcl2.Variable("foo", {"value": "bar"}),
     ),

--- a/tests/test_conversion/test_expressions.py
+++ b/tests/test_conversion/test_expressions.py
@@ -300,7 +300,9 @@ def test_find_in_map(fake_tc: TemplateConverter):
 
     expected_result = f"local.mappings[{map_name}][{top_level_key}][{second_level_key}]"
 
-    result = expressions.find_in_map(fake_tc, [map_name, top_level_key, second_level_key])
+    result = expressions.find_in_map(
+        fake_tc, [map_name, top_level_key, second_level_key]
+    )
 
     assert result == expected_result
 
@@ -378,7 +380,10 @@ def test_get_att_nested(fake_tc: TemplateConverter):
             [resource_id, test_attr],
         )
 
-    assert "Unable to solve nested GetAttr BucketName for test_stack and aws_s3_bucket" in str(e)
+    assert (
+        "Unable to solve nested GetAttr BucketName for test_stack and aws_s3_bucket"
+        in str(e)
+    )
 
     resource_props["Type"] = "AWS::CloudFormation::Stack"
 
@@ -417,7 +422,9 @@ def test_get_azs(fake_tc: TemplateConverter):
     result = expressions.get_azs(fake_tc, "Testing")
     assert result == expected
 
-    data_blocks = [data for data in fake_tc.post_proccess_blocks if isinstance(data, hcl2.Data)]
+    data_blocks = [
+        data for data in fake_tc.post_proccess_blocks if isinstance(data, hcl2.Data)
+    ]
 
     # Make sure the datasource was added correctly
     assert len(data_blocks) != 0 and data_blocks[0].name == '"available"'
@@ -676,12 +683,6 @@ sub_l_tests = [
     (
         ["some ${foo} ${bar}", {"bar": "var.foo"}],
         "some ${var.foo} ${var.foo}",
-        no_exception(),
-        hcl2.Variable("foo", {"value": "bar"}),
-    ),
-    (
-        ["some $foo", {"foo": "bar"}],
-        "some $foo",
         no_exception(),
         hcl2.Variable("foo", {"value": "bar"}),
     ),

--- a/tests/test_conversion/test_expressions.py
+++ b/tests/test_conversion/test_expressions.py
@@ -300,9 +300,7 @@ def test_find_in_map(fake_tc: TemplateConverter):
 
     expected_result = f"local.mappings[{map_name}][{top_level_key}][{second_level_key}]"
 
-    result = expressions.find_in_map(
-        fake_tc, [map_name, top_level_key, second_level_key]
-    )
+    result = expressions.find_in_map(fake_tc, [map_name, top_level_key, second_level_key])
 
     assert result == expected_result
 
@@ -380,10 +378,7 @@ def test_get_att_nested(fake_tc: TemplateConverter):
             [resource_id, test_attr],
         )
 
-    assert (
-        "Unable to solve nested GetAttr BucketName for test_stack and aws_s3_bucket"
-        in str(e)
-    )
+    assert "Unable to solve nested GetAttr BucketName for test_stack and aws_s3_bucket" in str(e)
 
     resource_props["Type"] = "AWS::CloudFormation::Stack"
 
@@ -422,9 +417,7 @@ def test_get_azs(fake_tc: TemplateConverter):
     result = expressions.get_azs(fake_tc, "Testing")
     assert result == expected
 
-    data_blocks = [
-        data for data in fake_tc.post_proccess_blocks if isinstance(data, hcl2.Data)
-    ]
+    data_blocks = [data for data in fake_tc.post_proccess_blocks if isinstance(data, hcl2.Data)]
 
     # Make sure the datasource was added correctly
     assert len(data_blocks) != 0 and data_blocks[0].name == '"available"'
@@ -683,6 +676,12 @@ sub_l_tests = [
     (
         ["some ${foo} ${bar}", {"bar": "var.foo"}],
         "some ${var.foo} ${var.foo}",
+        no_exception(),
+        hcl2.Variable("foo", {"value": "bar"}),
+    ),
+    (
+        ["some $foo", {"foo": "bar"}],
+        "some $foo",
         no_exception(),
         hcl2.Variable("foo", {"value": "bar"}),
     ),

--- a/tests/test_conversion/test_expressions.py
+++ b/tests/test_conversion/test_expressions.py
@@ -686,6 +686,12 @@ sub_l_tests = [
         no_exception(),
         hcl2.Variable("foo", {"value": "bar"}),
     ),
+    (
+        ["some $foo", {"foo": "bar"}],
+        "some $foo",
+        no_exception(),
+        hcl2.Variable("foo", {"value": "bar"}),
+    ),
     pytest.param(
         ["some ${foo} ${bar}", {"bar": "some string"}],
         "some ${var.foo} some string",


### PR DESCRIPTION
Ran into similar 'NoneType is not iterable' issue from https://github.com/DontShaveTheYak/cf2tf/issues/38 / https://github.com/DontShaveTheYak/cf2tf/pull/39  and it seems the difference is that it has a list child and not a string child.

template: https://s3.amazonaws.com/dagster.cloud/cloudformation/ecs-agent-vpc.yaml
<details><summary>snippet</summary>

```yaml
          Command:
            - !Sub
              - |-
                /bin/bash -c "
                mkdir -p $DAGSTER_HOME && echo 'instance_class:
                  module: dagster_cloud
                  class: DagsterCloudAgentInstance

                dagster_cloud_api:
                  url: \"https://${DagsterOrganization}.agent.dagster.cloud\"
                  agent_token: \"${AgentToken}\"
                  ${DeploymentConfig}
                  branch_deployments: ${EnableBranchDeployments}
```
</details>

although it still doesn't seem to create a proper multiline string after the fix, that is easy enough to fix in post