### PR TITLE
Add ability to convert Cloudformation ImportValue

### DIFF
--- a/src/cf2tf/conversion/expressions.py
+++ b/src/cf2tf/conversion/expressions.py
@@ -499,14 +499,22 @@ def get_azs(template: "TemplateConverter", region: Any):
 
 # todo Handle functions that are not applicable to terraform.
 def import_value(template: "TemplateConverter", name: Any):
-    # I'm not sure how to handle this but I think if any exception is encountered while
-    # converting cf expressions to terraform, we should just comment out the entire line.
+    if not isinstance(name, str):
+        raise TypeError(
+            f"The import value type was expected to be string not {type(name)}"
+        )
 
-    # On second thought it probably makes sense to turn this into a input variable
-
-    raise Exception(
-        "Fn::Import Is Cloudformation native and unable to be converted to a Terraform expression."
+    var = hcl2.Variable(
+        name,
+        {
+            "description": StringType(
+                "This variable was an imported value in the Cloudformation Template."
+            )
+        },
     )
+
+    template.add_post_block(var)
+    return LiteralType(var.base_ref())
 
 
 def join(_tc: "TemplateConverter", values: Any):

--- a/src/cf2tf/terraform/blocks.py
+++ b/src/cf2tf/terraform/blocks.py
@@ -11,7 +11,7 @@ log = logging.getLogger("cf2tf")
 
 class Variable(Block):
     def __init__(self, name: str, arguments: Dict[str, Any]) -> None:
-        self.name = f'"{name}"'
+        self.name = name
 
         valid_arguments = ["description", "type", "default"]
         super().__init__("variable", (self.name,), arguments, valid_arguments, [])
@@ -21,6 +21,11 @@ class Variable(Block):
         self.arguments["type"] = self.arguments["type"].strip('"')
 
         return super().write()
+
+    def base_ref(self):
+        ref = super().base_ref()
+
+        return ref.replace("variable", "var")
 
 
 class Locals(Block):

--- a/tests/test_conversion/test_expressions.py
+++ b/tests/test_conversion/test_expressions.py
@@ -470,6 +470,12 @@ def test_get_azs(fake_tc: TemplateConverter):
     assert len(data_blocks) != 0 and data_blocks[0].name == '"available"'
 
 
+def test_import_value(fake_tc: TemplateConverter):
+    result = expressions.import_value(fake_tc, "Some-CF-Import-Name")
+
+    assert result == "var.Some-CF-Import-Name"
+
+
 join_tests = [
     (None, ['"-"', "var.something"], 'join("-", var.something)'),
     (None, ['"-"', ["A", "B", "C"]], 'join("-", [A, B, C])'),


### PR DESCRIPTION
We achieve this by taking the name of the import value and converting it to a Terraform variable and referencing it.

Closes #69 