### PR TITLE
Automatically convert Cloudformation tags to Terraform format. 

### DIFF
--- a/src/cf2tf/conversion/overrides.py
+++ b/src/cf2tf/conversion/overrides.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Callable, Dict
 
 from cf2tf.terraform.hcl2.custom import LiteralType
 from cf2tf.terraform.hcl2.primitive import NullType, StringType, TerraformType
+from cf2tf.terraform.hcl2.complex import ListType, MapType
 
 if TYPE_CHECKING:
     from cf2tf.convert import TemplateConverter
@@ -45,7 +46,20 @@ def s3_bucket_policy(_tc: "TemplateConverter", params: CFParams) -> CFParams:
     return params
 
 
+def tag_conversion(_tc: "TemplateConverter", params: CFParams) -> CFParams:
+    orginal_tags: ListType = params["Tags"]  # type: ignore
+
+    new_tags = {LiteralType(tag["Key"]): tag["Value"] for tag in orginal_tags}
+
+    del params["Tags"]
+    params["tags"] = MapType(new_tags)
+
+    return params
+
+
 OVERRIDE_DISPATCH: ResourceOverride = {
     "aws_s3_bucket": {"AccessControl": s3_bucket_acl},
     "aws_s3_bucket_policy": {"PolicyDocument": s3_bucket_policy},
 }
+
+GLOBAL_OVERRIDES: ParamOverride = {"Tags": tag_conversion}

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -153,6 +153,22 @@ def test_perform_resource_overrides():
     assert "private" == result["acl"]
 
 
+def test_perform_global_overrides():
+    template = tc()
+
+    params = {"Tags": [{"Key": "foo", "Value": "bar"}]}
+
+    result = convert.perform_global_overrides("aws_s3_bucket", params, template)
+
+    assert result is params
+
+    assert "Tags" not in result
+    assert "tags" in result
+    assert "foo" in result["tags"]
+    assert "bar" == result["tags"]["foo"]
+    assert isinstance(result["tags"], dict)
+
+
 parse_subsection_tests = [
     # (tf_arg_name, cf_props, docs_path, expected_type, expectation)
     (


### PR DESCRIPTION
Cloudformation commonly uses [{"Key":"SomeKey", "Value":"SomeValue"}] for tags where terraform uses {"SomeKey":"SomeValue"}. This new global overide will convert the CF tags to TF tags for any CF resource with a "Tags" property.

Closes #62 

Better late than never 😏 