### PR TITLE
change search algorithm to get better search results

### DIFF
--- a/src/cf2tf/terraform/code.py
+++ b/src/cf2tf/terraform/code.py
@@ -35,7 +35,7 @@ class SearchManager:
         ranking: int
         doc_path: Path
         resource_name, ranking, doc_path = process.extractOne(
-            name.lower(), files, scorer=fuzz.UWRatio
+            name.lower(), files, scorer=fuzz.token_sort_ratio
         )
 
         log.debug(

--- a/tests/test_terraform/test_code.py
+++ b/tests/test_terraform/test_code.py
@@ -6,26 +6,42 @@ from cf2tf.terraform.code import (
     SearchManager,
     resource_type_to_name,
     transform_file_name,
+    search_manager,
 )
 
 
 @pytest.fixture()
-def sm():
+def mock_sm():
     test_docs = Path(__file__) / "./../../data/docs"
     return SearchManager(test_docs.resolve())
 
 
-def test_sm_(sm: SearchManager):
-    assert len(sm.resources) == 2
-    assert len(sm.datas) == 1
+@pytest.fixture(scope="session")
+def sm():
+    return search_manager()
 
 
-def test_sm_find(sm: SearchManager):
-    aws_resource_type = "AWS::ApiGatewayV2::Integration"
+def test_sm_(mock_sm: SearchManager):
+    assert len(mock_sm.resources) == 2
+    assert len(mock_sm.datas) == 1
 
-    result = sm.find(aws_resource_type)
 
-    assert result.name == "apigatewayv2_integration.markdown"
+sm_find_tests = [
+    ("AWS::ApiGatewayV2::Integration", "apigatewayv2_integration.html.markdown"),
+    ("AWS::Lambda::Function", "lambda_function.html.markdown"),
+    ("AWS::EC2::Instance", "instance.html.markdown"),
+    ("AWS::Events::Rule", "cloudwatch_event_rule.html.markdown"),
+    ("AWS::Cognito::UserPool", "cognito_user_pool.markdown"),
+]
+
+
+@pytest.mark.parametrize("cf_resource, tf_doc_name", sm_find_tests)
+def test_sm_find(cf_resource: str, tf_doc_name: str, request):
+    sm: SearchManager = request.getfixturevalue("sm")
+
+    result = sm.find(cf_resource)
+
+    assert result.name == tf_doc_name
 
 
 def test_transform_file_name():


### PR DESCRIPTION
The previous algorithm would use multiple algorithms and then return The result that had the highest score. This would make a 
 search for `event rule`, match with `vpc_security_group_rule` instead of `cloudwatch_event_rule`.

I will use a minor bump as this will likely change the existing functionality for better or perhaps worse.
