### PR TITLE
Fix bug when parsing attributes that are nested

### DIFF
--- a/src/cf2tf/app.py
+++ b/src/cf2tf/app.py
@@ -14,7 +14,7 @@ log = logging.getLogger("cf2tf")
 click_log.basic_config(log)
 
 
-@click.command()
+@click.command()  # type: ignore
 @click.version_option()
 @click.option("--output", "-o", type=click.Path(exists=False))
 @click_log.simple_verbosity_option(log)
@@ -48,4 +48,4 @@ def cli(output: Optional[str], template_path: str):
 
 
 if __name__ == "__main__":
-    cli()
+    cli()  # type: ignore

--- a/src/cf2tf/terraform/doc_file.py
+++ b/src/cf2tf/terraform/doc_file.py
@@ -10,9 +10,15 @@ log = logging.getLogger("cf2tf")
 
 def parse_attributes(docs_path: Path):
     with open(docs_path) as file:
-        arguments = parse_section("Argument Reference", file)
+        try:
+            arguments = parse_section("Argument Reference", file)
+        except Exception as e:
+            raise Exception(f"Unable to find arguments in {file.name}") from e
 
-        attributes = parse_section("Attributes Reference", file)
+        try:
+            attributes = parse_section("Attributes Reference", file)
+        except Exception as e:
+            raise Exception(f"Unable to find attributes in {file.name}") from e
 
     return (arguments, attributes)
 
@@ -61,7 +67,7 @@ def parse_items(file: TextIOWrapper):
 
         # These should be the attributes we are after
         if line[0] == "*":
-            regex = r"`([\w\.]+)`"
+            regex = r"`([\w.*]+)`"
 
             match = re.search(regex, line)
 


### PR DESCRIPTION
Some Terraform resources have nested attributes.  For example, the dynamodb table has "replica.*.arn". This patch will now return the first word for nested attributes.  In this case, it will return "replica".