### PR TITLE
fix automatic tag conversion error when tags are already a map

### DIFF
--- a/src/cf2tf/conversion/overrides.py
+++ b/src/cf2tf/conversion/overrides.py
@@ -47,6 +47,9 @@ def s3_bucket_policy(_tc: "TemplateConverter", params: CFParams) -> CFParams:
 
 
 def tag_conversion(_tc: "TemplateConverter", params: CFParams) -> CFParams:
+    if isinstance(params["Tags"], dict):
+        return params
+
     orginal_tags: ListType = params["Tags"]  # type: ignore
 
     new_tags = {LiteralType(tag["Key"]): tag["Value"] for tag in orginal_tags}


### PR DESCRIPTION
Some resources have tags that are already a map, and the automatic tag conversion would fail. This commit fixes that by checking if the tags are already a map, and if so, it returns them as-is.