### PR TITLE
fix bug where a ref would fail if the resource had no attributes

### DIFF
--- a/src/cf2tf/conversion/expressions.py
+++ b/src/cf2tf/conversion/expressions.py
@@ -828,10 +828,11 @@ def ref(template: "TemplateConverter", var_name: str):
     if cf_resource:
         cf_resource_type = cf_resource.get("Type", "")
         docs_path = template.search_manager.find(cf_resource_type)
-        _, valid_attributes = doc_file.parse_attributes(docs_path)
+        valid_arguments, valid_attributes = doc_file.parse_attributes(docs_path)
         tf_name = cf2tf.convert.pascal_to_snake(var_name)
         tf_type = cf2tf.convert.create_resource_type(docs_path)
-        first_attr = next(iter(valid_attributes))
+
+        first_attr = valid_attributes[0] if valid_attributes else valid_arguments[0]
         conditional = cf_resource.get("Condition")
 
         if conditional is not None:


### PR DESCRIPTION
Some resources have no attributes, like the Congito UserPoolGroup. This fix adds a check to see if there are any attributes and if not will return the first argument. Because all arguments are valid attributes.