### PR TITLE
fix test arg path in vscode debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Python: Current File",
+      "name": "cf2tf: Test Template",
       "type": "python",
       "request": "launch",
       "program": "${workspaceFolder}/src/cf2tf/app.py",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "args": [
         "-v",
         "debug",
-        "tests/data/log_bucket.yaml"
+        "tests/data/templates/log_bucket.yaml"
       ],
       "justMyCode": true
     }


### PR DESCRIPTION
when running in vscode noticed this path was not up to date with current fixture location 
https://github.com/DontShaveTheYak/cf2tf/blob/28c3898e0818667cc8a1146dcd44826ce2504c03/tests/data/templates/log_bucket.yaml