### PR TITLE
add boolean type

### DIFF
--- a/src/cf2tf/convert.py
+++ b/src/cf2tf/convert.py
@@ -10,12 +10,17 @@ from thefuzz import process  # type: ignore
 import cf2tf.conversion.expressions as functions
 import cf2tf.terraform._configuration as config
 import cf2tf.terraform.doc_file as doc_file
-from cf2tf.conversion.overrides import OVERRIDE_DISPATCH, GLOBAL_OVERRIDES
+from cf2tf.conversion.overrides import GLOBAL_OVERRIDES, OVERRIDE_DISPATCH
 from cf2tf.terraform.blocks import Block, Locals, Output, Resource, Variable
 from cf2tf.terraform.hcl2 import AllTypes
 from cf2tf.terraform.hcl2.complex import ListType, MapType
 from cf2tf.terraform.hcl2.custom import CommentType, LiteralType
-from cf2tf.terraform.hcl2.primitive import NumberType, StringType, TerraformType
+from cf2tf.terraform.hcl2.primitive import (
+    BooleanType,
+    NumberType,
+    StringType,
+    TerraformType,
+)
 
 if TYPE_CHECKING:
     from cf2tf.terraform.code import SearchManager
@@ -196,6 +201,8 @@ class TemplateConverter:
             ]
 
             return ListType(resolved_list_values)
+        elif isinstance(data, bool):
+            return BooleanType(data)
         elif isinstance(data, str):
             return StringType(data)
         elif isinstance(data, (int, float)):

--- a/src/cf2tf/terraform/hcl2/primitive.py
+++ b/src/cf2tf/terraform/hcl2/primitive.py
@@ -89,4 +89,24 @@ class NullType(int, TerraformType):
         return __x == self.value
 
 
-PrimitiveTypes = Union[StringType, NumberType, NullType]
+class BooleanType(int, TerraformType):
+    """A value that represents a boolean."""
+
+    def __init__(self, value: bool) -> None:
+        """Default constructor
+
+        Args:
+            value (bool): The value for this Terraform type.
+        """
+        super().__init__()
+
+        self.value: bool = value
+
+    def __str__(self) -> str:
+        return self.render()
+
+    def render(self, _=0):
+        return str(self.value).lower()
+
+
+PrimitiveTypes = Union[StringType, NumberType, NullType, BooleanType]

--- a/tests/test_terraform/test_configuration.py
+++ b/tests/test_terraform/test_configuration.py
@@ -2,6 +2,11 @@ import pytest
 
 from cf2tf.convert import TemplateConverter
 from cf2tf.terraform import code
+from cf2tf.terraform.hcl2.primitive import (
+    BooleanType,
+    NumberType,
+    StringType,
+)
 
 
 def tc() -> TemplateConverter:
@@ -26,3 +31,22 @@ def test_resolve_values(input, expected_result, tc: TemplateConverter):
     result = tc.resolve_values(input, {})
 
     assert result == expected_result
+
+
+resolves_types_tests = [
+    # (input, expected_result, rendered_value, tc)
+    ("foo", StringType, '"foo"', tc()),
+    (123, NumberType, 123, tc()),
+    (True, BooleanType, "true", tc()),
+    (False, BooleanType, "false", tc()),
+]
+
+
+@pytest.mark.parametrize(
+    "input, expected_result, rendered_value, tc", resolves_types_tests
+)
+def test_resolve_types(input, expected_result, rendered_value, tc: TemplateConverter):
+    result = tc.resolve_values(input, {})
+
+    assert isinstance(result, expected_result)
+    assert result.render() == rendered_value


### PR DESCRIPTION
looking into https://github.com/DontShaveTheYak/cf2tf/issues/214

Terraform booleans are supposed to be like so: `true` `false` but at the moment we are not rendering them like this in conversion