### PR TITLE
Fix several issues with nested functions

### DIFF
--- a/src/cf2tf/conversion/expressions.py
+++ b/src/cf2tf/conversion/expressions.py
@@ -982,6 +982,7 @@ ALLOWED_FUNCTIONS: Dict[str, Dispatch] = {
         **ALLOWED_NESTED_CONDITIONS,
         "Fn::Join": join,
         "Fn::Select": select,
+        "Fn::Sub": sub,
     },
     "Fn::If": {
         "Fn::Base64": base64,

--- a/src/cf2tf/conversion/expressions.py
+++ b/src/cf2tf/conversion/expressions.py
@@ -994,6 +994,7 @@ ALLOWED_FUNCTIONS: Dict[str, Dispatch] = {
         "Fn::Select": select,
         "Fn::Sub": sub,
         "Ref": ref,
+        "Fn::Split": split,
     },
     "Fn::Not": ALLOWED_NESTED_CONDITIONS,
     "Fn::Or": ALLOWED_NESTED_CONDITIONS,

--- a/src/cf2tf/conversion/expressions.py
+++ b/src/cf2tf/conversion/expressions.py
@@ -359,19 +359,68 @@ def get_att(template: "TemplateConverter", values: Any):
         values (Any): The values passed to the function.
 
     Raises:
-        TypeError: If values is not a list.
-        ValueError: If length of values is not 3.
-        TypeError: If the logicalNameOfResource and attributeName are not str.
-        KeyError: If the logicalNameOfResource is not found in the template.
+        TypeError: If values is not a String.
 
     Returns:
-        str: Terraform equivalent expression.
+        LiteralType: Terraform equivalent expression.
     """
 
-    if not isinstance(values, List):
-        raise TypeError(
-            f"Fn::GetAtt - The values must be a List, not {type(values).__name__}."
+    if isinstance(values, (str, StringType)):
+        return _get_att_string(template, values)
+
+    if isinstance(values, list):
+        return _get_att_list(template, values)
+
+    raise TypeError(
+        f"Fn::GetAtt - The value must be a String or List, not {type(values).__name__}."
+    )
+
+
+def _get_att_string(template: "TemplateConverter", values: Any):
+    """Converts AWS GetAtt intrinsic function to it's Terraform equivalent.
+
+    Args:
+        template (Configuration): The template being tested.
+        values (Any): The values passed to the function.
+
+    Raises:
+        ValueError: If the value doesn't contain a resource id and an attribute.
+
+    Returns:
+        LiteralType: Terraform equivalent expression.
+    """
+
+    if "." not in values:
+        raise ValueError(
+            "Fn::GetAtt - The value must contain a resource id and an attribute."
         )
+
+    parts = values.split(".")
+
+    resouce_id = parts[0]
+
+    attributes = ".".join(parts[1:])
+
+    result = _get_att_list(template, [resouce_id, attributes])
+
+    return result
+
+
+def _get_att_list(template: "TemplateConverter", values: Any):
+    """Converts AWS GetAtt intrinsic function to it's Terraform equivalent.
+
+    Args:
+        template (Configuration): The template being tested.
+        values (Any): The values passed to the function.
+
+    Raises:
+        ValueError: If the values length is not 2.
+        TypeError: If the values are not strings.
+
+    Returns:
+        LiteralType: Terraform equivalent expression.
+    """
+
     if not len(values) == 2:
         raise ValueError(
             (
@@ -712,7 +761,7 @@ def sub_s(template: "TemplateConverter", value: str):
 
             attributes = ".".join(parts[1:])
 
-            result = get_att(template, [resouce_id, attributes])
+            result = _get_att_list(template, [resouce_id, attributes])
         else:
             result = ref(template, var)
 
@@ -775,7 +824,7 @@ def sub_l(template: "TemplateConverter", values: List):
 
             attributes = ".".join(parts[1:])
 
-            result = get_att(template, [resouce_id, attributes])
+            result = _get_att_list(template, [resouce_id, attributes])
         else:
             result = ref(template, var)
 
@@ -1003,6 +1052,7 @@ ALLOWED_FUNCTIONS: Dict[str, Dispatch] = {
     "Fn::Cidr": {
         "Fn::Select": select,
         "Ref": ref,
+        "Fn::GetAtt": get_att,
     },
     "Fn::FindInMap": {
         "Fn::FindInMap": find_in_map,

--- a/src/cf2tf/convert.py
+++ b/src/cf2tf/convert.py
@@ -205,8 +205,10 @@ class TemplateConverter:
 
                 try:
                     return allowed_func[key](self, value)
-                except Exception:
-                    return CommentType(f"Unable to resolve {key} with value: {value}")
+                except Exception as e:
+                    return CommentType(
+                        f"Unable to resolve {key} with value: {value} because {e}"
+                    )
 
             return MapType(data)
         elif isinstance(data, list):

--- a/src/cf2tf/convert.py
+++ b/src/cf2tf/convert.py
@@ -173,10 +173,7 @@ class TemplateConverter:
                 # This takes care of keys that not intrinsic functions,
                 #  except for the condition func
                 if "Fn::" not in key and key != "Condition":
-                    data[key] = self.resolve_values(
-                        value,
-                        allowed_func,
-                    )
+                    data[key] = self.resolve_values(value, allowed_func, prev_func)
                     continue
 
                 # Takes care of the tricky 'Condition' key
@@ -194,17 +191,16 @@ class TemplateConverter:
                         return functions.condition(self, value)
 
                     # Normal key like in an IAM role
-                    data[key] = self.resolve_values(
-                        value,
-                        allowed_func,
-                    )
+                    data[key] = self.resolve_values(value, allowed_func, prev_func)
                     continue
 
                 if key not in allowed_func:
                     raise ValueError(f"{key} not allowed to be nested in {prev_func}.")
 
+                prev_func = key
+
                 value = self.resolve_values(
-                    value, functions.ALLOWED_FUNCTIONS[key], key
+                    value, functions.ALLOWED_FUNCTIONS[key], prev_func
                 )
 
                 try:

--- a/tests/test_conversion/test_expressions.py
+++ b/tests/test_conversion/test_expressions.py
@@ -298,11 +298,20 @@ def test_find_in_map(fake_tc: TemplateConverter):
 
 
 def test_get_att(fake_tc: TemplateConverter):
-    # Test that it will only take a list
+
     with pytest.raises(TypeError) as type_error:
         expressions.get_att(fake_tc, {})
 
-    assert "Fn::GetAtt - The values must be a List, not dict." in str(type_error)
+    assert "Fn::GetAtt - The value must be a String or List, not dict." in str(
+        type_error
+    )
+    # Test that string must be in the correct format
+    with pytest.raises(ValueError) as value_error:
+        expressions.get_att(fake_tc, "foo")
+
+    assert "Fn::GetAtt - The value must contain a resource id and an attribute." in str(
+        value_error
+    )
 
     # Test that list size must be two
     with pytest.raises(ValueError) as value_error:
@@ -340,6 +349,10 @@ def test_get_att(fake_tc: TemplateConverter):
     test_attr = "template_url"
     expected_result = f"aws_cloudformation_stack.{resource_id}.{test_attr}"
     result = expressions.get_att(fake_tc, [resource_id, test_attr])
+
+    assert result == expected_result
+
+    result = expressions.get_att(fake_tc, f"{resource_id}.{test_attr}")
 
     assert result == expected_result
 
@@ -394,7 +407,7 @@ def test_get_att_nested(fake_tc: TemplateConverter):
 
     expected_result = f"aws_cloudformation_stack.{resource_id}.{test_attr.lower()}"
 
-    result = expressions.get_att(fake_tc, [resource_id, test_attr])
+    result = expressions.get_att(fake_tc, f"{resource_id}.{test_attr}")
 
     assert result == expected_result
 


### PR DESCRIPTION
The AWS documentation on where functions are allowed to be nested is plain ole wrong. We are contantly finding new combinations from AWS's own templates.

This PR also adds better logging and error handling.