### PR TITLE
Modify search algorithm to improve conversion of resources types

### DIFF
--- a/src/cf2tf/terraform/code.py
+++ b/src/cf2tf/terraform/code.py
@@ -11,7 +11,7 @@ from git import RemoteProgress
 from git.repo.base import InvalidGitRepositoryError, Repo
 from thefuzz import fuzz, process  # type: ignore
 
-import cf2tf.convert
+# import cf2tf.convert
 
 log = logging.getLogger("cf2tf")
 
@@ -35,7 +35,7 @@ class SearchManager:
         ranking: int
         doc_path: Path
         resource_name, ranking, doc_path = process.extractOne(
-            name.lower(), files, scorer=fuzz.token_sort_ratio
+            name.lower(), files, scorer=fuzz.ratio
         )
 
         log.debug(
@@ -109,9 +109,11 @@ def resource_type_to_name(resource_type: str) -> str:
 
     search_tokens = resource_type.replace("::", " ").replace("AWS", " ").split(" ")
 
-    for i, token in enumerate(search_tokens):
-        if len(token) >= 4:
-            search_tokens[i] = cf2tf.convert.camel_case_split(token)
+    # I will leave the logic for camel case splitting here for now.
+    # in case we want to use it later.
+    # for i, token in enumerate(search_tokens):
+    #     if len(token) >= 4:
+    #         search_tokens[i] = cf2tf.convert.camel_case_split(token)
 
     search_term = " ".join(search_tokens).lower().strip()
 

--- a/src/cf2tf/terraform/code.py
+++ b/src/cf2tf/terraform/code.py
@@ -1,14 +1,14 @@
 import logging
 import re
 from pathlib import Path
+from shutil import rmtree
 from tempfile import gettempdir
 from typing import Optional
-from shutil import rmtree
 
 import click
 from click._termui_impl import ProgressBar
 from git import RemoteProgress
-from git.repo.base import Repo, InvalidGitRepositoryError
+from git.repo.base import InvalidGitRepositoryError, Repo
 from thefuzz import fuzz, process  # type: ignore
 
 import cf2tf.convert

--- a/src/cf2tf/terraform/doc_file.py
+++ b/src/cf2tf/terraform/doc_file.py
@@ -1,9 +1,8 @@
+import logging
+import re
 from io import TextIOWrapper
 from pathlib import Path
 from typing import List
-import re
-
-import logging
 
 log = logging.getLogger("cf2tf")
 

--- a/src/cf2tf/terraform/doc_file.py
+++ b/src/cf2tf/terraform/doc_file.py
@@ -88,7 +88,7 @@ def parse_items(file: TextIOWrapper):
             continue
 
         # These should be the attributes we are after
-        if line[0] == "*":
+        if line[0] == "*" or line[0] == "-":
             regex = r"`([\w.*]+)`"
 
             match = re.search(regex, line)

--- a/tests/test_terraform/test_code.py
+++ b/tests/test_terraform/test_code.py
@@ -5,8 +5,8 @@ import pytest
 from cf2tf.terraform.code import (
     SearchManager,
     resource_type_to_name,
-    transform_file_name,
     search_manager,
+    transform_file_name,
 )
 
 

--- a/tests/test_terraform/test_code.py
+++ b/tests/test_terraform/test_code.py
@@ -31,6 +31,7 @@ sm_find_tests = [
     ("AWS::Lambda::Function", "lambda_function.html.markdown"),
     ("AWS::Events::Rule", "cloudwatch_event_rule.html.markdown"),
     ("AWS::Cognito::UserPool", "cognito_user_pool.html.markdown"),
+    ("AWS::AutoScaling::AutoScalingGroup", "autoscaling_group.html.markdown"),
 ]
 
 
@@ -51,8 +52,8 @@ def test_transform_file_name():
 
 type_to_name_tests = [
     ("AWS::Ec2::Instance", "ec2 instance"),
-    ("AWS::EC2::RouteTable", "ec2 route table"),
-    ("AWS::RDS::DBSubnetGroup", "rds db subnet group"),
+    ("AWS::EC2::RouteTable", "ec2 routetable"),
+    ("AWS::RDS::DBSubnetGroup", "rds dbsubnetgroup"),
     ("AWS::S3::Bucket", "s3 bucket"),
 ]
 


### PR DESCRIPTION
This should result in better matches when converting a resource from Cloudformation to Terraform. In my limited local testing I was able to match on more resources correctly while not breaking any of the tricky conversions we already test against. 

I also fixed a bug where we were not parsing attributes in the Terraform docs correctly because we only checked for one type of markdown list item, when there is a second valid list item possible. It was discussed in #290 