### PR TITLE
Feature/fix tags parsing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,3 +58,4 @@ RUN curl -sSL https://install.python-poetry.org | python3 -
 
 # Install nox and pre-commit to automate CI stuff
 RUN pip install --user --upgrade nox nox_poetry pre-commit
+RUN git config --global --add safe.directory /workspaces/cf2tf

--- a/src/cf2tf/conversion/overrides.py
+++ b/src/cf2tf/conversion/overrides.py
@@ -53,7 +53,6 @@ def tag_conversion(_tc: "TemplateConverter", params: CFParams) -> CFParams:
     original_tags: ListType = params["Tags"]  # type: ignore
     # Handle Cloudformation templates that generate Tags: []
     if not original_tags:
-        params["tags"] = params["Tags"]
         del params["Tags"]
         return params
 

--- a/src/cf2tf/conversion/overrides.py
+++ b/src/cf2tf/conversion/overrides.py
@@ -51,6 +51,11 @@ def tag_conversion(_tc: "TemplateConverter", params: CFParams) -> CFParams:
         return params
 
     original_tags: ListType = params["Tags"]  # type: ignore
+    # Handle Cloudformation templates that generate Tags: []
+    if not original_tags:
+        params["tags"] = params["Tags"]
+        del params["Tags"]
+        return params
 
     first_item = original_tags[0]
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -167,9 +167,8 @@ def test_perform_global_overrides():
 
     assert result is empty_params
     assert "Tags" not in result
-    assert "tags" in result
-    assert isinstance(result["tags"], list)
-    assert [] == result["tags"]
+    assert "tags" not in result
+    assert {} == result
 
     params = {"Tags": [{"Key": "foo", "Value": "bar"}]}
     result = convert.perform_global_overrides("aws_s3_bucket", params, template)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -6,7 +6,7 @@ import pytest
 
 import cf2tf.convert as convert
 from cf2tf.terraform import code, doc_file
-from cf2tf.terraform.blocks import Data, Locals, Output, Block
+from cf2tf.terraform.blocks import Block, Data, Locals, Output
 from cf2tf.terraform.hcl2.primitive import StringType
 
 
@@ -162,8 +162,16 @@ def test_perform_resource_overrides():
 def test_perform_global_overrides():
     template = tc()
 
-    params = {"Tags": [{"Key": "foo", "Value": "bar"}]}
+    empty_params = {"Tags": []}
+    result = convert.perform_global_overrides("aws_s3_bucket", empty_params, template)
 
+    assert result is empty_params
+    assert "Tags" not in result
+    assert "tags" in result
+    assert isinstance(result["tags"], list)
+    assert [] == result["tags"]
+
+    params = {"Tags": [{"Key": "foo", "Value": "bar"}]}
     result = convert.perform_global_overrides("aws_s3_bucket", params, template)
 
     assert result is params


### PR DESCRIPTION
Resolves issue encountered in https://github.com/DontShaveTheYak/cf2tf/issues/325

Cloudformation generates templates with Tags: [] output on us-east-2 for me on a relatively brand new account with EC2, S3, Route53, ACM, and Cloudfront. 

Previously this would cause issues getting cf2tf to compile https://github.com/DontShaveTheYak/cf2tf/issues/325

This PR adjusts the behavior to safely handle the empty list.

Fixes #325 